### PR TITLE
Use username as provided by the requests auth object.

### DIFF
--- a/grouper_ws/api.py
+++ b/grouper_ws/api.py
@@ -33,7 +33,6 @@ class Grouper(object):
     def __init__(self, host_name, base_url, auth=HTTPNegotiateAuth()):
         self.host_name = host_name
         self.base_url = urljoin('https://' + self.host_name, base_url)
-        self.username = "cud/arbitrary.it.ox.ac.uk@OX.AC.UK"
         self.auth = auth
         self.__session = requests.Session()
 
@@ -70,7 +69,7 @@ class Grouper(object):
 
         data = {
             'WsRestAddMemberRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'replaceAllExisting': bool_to_tf_str(replace_existing),
                 'subjectLookups': members_list,
             },
@@ -85,7 +84,7 @@ class Grouper(object):
 
         data = {
             'WsRestFindGroupsRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'wsQueryFilter': query.to_json_dict(),
             },
         }
@@ -100,7 +99,7 @@ class Grouper(object):
 
         data = {
             'WsRestFindGroupsRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'wsGroupLookups': group_list,
                 'includeGroupDetail': 'T',
             },
@@ -121,7 +120,7 @@ class Grouper(object):
 
         data = {
             'WsRestHasMemberRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'subjectLookups': members_list,
             },
         }
@@ -136,7 +135,7 @@ class Grouper(object):
 
         data = {
             'WsRestGetMembersRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'subjectAttributeNames': subject_attributes,
                 'wsGroupLookups': group_list,
             },
@@ -154,7 +153,7 @@ class Grouper(object):
 
         data = {
             'WsRestGetMembershipsRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'subjectAttributeNames': subject_attributes,
                 #'memberFilter': 'All',
                 'includeGroupDetail': 'T',
@@ -179,7 +178,7 @@ class Grouper(object):
 
         data = {
             'WsRestGroupSaveRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'includeGroupDetail': 'T',
                 'wsGroupToSaves': [g.to_json_dict() for g in groups],
             },
@@ -200,7 +199,7 @@ class Grouper(object):
 
         data = {
             'WsRestStemSaveRequest': {
-                'actAsSubjectLookup': {'subjectId': self.username},
+                'actAsSubjectLookup': {'subjectId': self.auth.username},
                 'wsStemToSaves': [s for s in stems],
             },
         }


### PR DESCRIPTION
Removed hard-coded username; now gets from auth object.

I've also just pushed a v1.1 of requests-negotiate to expose the username.
