### PR TITLE
Python3 support

### DIFF
--- a/grouper_ws/__init__.py
+++ b/grouper_ws/__init__.py
@@ -1,1 +1,1 @@
-from api import Grouper
+from .api import Grouper

--- a/grouper_ws/api.py
+++ b/grouper_ws/api.py
@@ -1,13 +1,21 @@
+from __future__ import absolute_import
+
 import base64
 import json
 import requests
 import logging
+
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
+
 from requests_kerberos import HTTPKerberosAuth
-from urlparse import urljoin
-from urllib import quote
-from groups import *
-from stems import *
-from subjects import *
+
+from .groups import *
+from .stems import *
+from .subjects import *
 
 
 DEFAULT_SUBJECT_ATTRIBUTES = [

--- a/grouper_ws/api.py
+++ b/grouper_ws/api.py
@@ -11,7 +11,7 @@ except ImportError: # Py2
     from urlparse import urljoin
     from urllib import quote
 
-from requests_kerberos import HTTPKerberosAuth
+from requests_negotiate import HTTPNegotiateAuth
 
 from .groups import *
 from .stems import *
@@ -65,7 +65,7 @@ def str_to_group(group):
 
 
 class Grouper(object):
-    def __init__(self, host_name, base_url, auth=HTTPKerberosAuth()):
+    def __init__(self, host_name, base_url, auth=HTTPNegotiateAuth()):
         self.host_name = host_name
         self.base_url = urljoin('https://' + self.host_name, base_url)
         self.auth = auth

--- a/grouper_ws/groups.py
+++ b/grouper_ws/groups.py
@@ -1,9 +1,16 @@
+from __future__ import absolute_import
+
 import base64
-import json
-from urlparse import urljoin
-from urllib import quote
 from datetime import datetime
-from subjects import Subject
+import json
+
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
+
+from .subjects import Subject
 
 
 class Group(object):

--- a/grouper_ws/queries.py
+++ b/grouper_ws/queries.py
@@ -1,11 +1,15 @@
-#!/usr/bin/env python
+from __future__ import absolute_import
 
 import base64
 import json
-import requests
-from urlparse import urljoin
-from urllib import quote
 
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
+
+import requests
 
 AND = 'AND'
 FIND_BY_APPROXIMATE_ATTRIBUTE = 'FIND_BY_APPROXIMATE_ATTRIBUTE'

--- a/grouper_ws/rules.py
+++ b/grouper_ws/rules.py
@@ -1,11 +1,18 @@
+from __future__ import absolute_import
+
 import base64
+from datetime import datetime
 import json
 import logging
-from urlparse import urljoin
-from urllib import quote
-from datetime import datetime
-from stems import *
-from subjects import Subject
+
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
+
+from .stems import *
+from .subjects import Subject
 
 
 RULES_ATTRIBUTE_BASE = "etc:attribute:rules"

--- a/grouper_ws/stem_queries.py
+++ b/grouper_ws/stem_queries.py
@@ -1,11 +1,17 @@
-#!/usr/bin/env python
+from __future__ import absolute_import
 
 import base64
 import json
+
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
+
 import requests
-from urlparse import urljoin
-from urllib import quote
-from queries import *
+
+from .queries import *
 
 
 AND = 'AND'

--- a/grouper_ws/stems.py
+++ b/grouper_ws/stems.py
@@ -1,9 +1,14 @@
-import base64
-import json
-from urlparse import urljoin
-from urllib import quote
-from datetime import datetime
+from __future__ import absolute_import
 
+import base64
+from datetime import datetime
+import json
+
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
 
 class Stem(object):
     def __init__(self, stem_name, display_name=None, uuid=None, *args, **kwargs):

--- a/grouper_ws/subjects.py
+++ b/grouper_ws/subjects.py
@@ -1,9 +1,14 @@
-import base64
-import json
-from urlparse import urljoin
-from urllib import quote
-from datetime import datetime
+from __future__ import absolute_import
 
+import base64
+from datetime import datetime
+import json
+
+try: # Py3
+    from urllib.parse import quote, urljoin
+except ImportError: # Py2
+    from urlparse import urljoin
+    from urllib import quote
 
 class Subject(object):
     def __init__(self, subject_id=None, source_id=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.0.0,<2.4
-requests-kerberos>=0.5
+requests-negotiate==1.1
 


### PR DESCRIPTION
Mostly import changes, but also moved to `requests-negotiate` as it supports Py3 (it depends on `python-gssapi`, whereas `requests-kerberos` requires `kerberos` which uses the `commands` module which was removed between Py2 and Py3).
